### PR TITLE
Backend Development: fix: Restrict unauthenticated access to some important pages. #Issue63

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ app.permanent_session_lifetime = timedelta(days=7)
 # init db
 init_db(app)
 
+# custom login required decorator
+# this decorator is used to check if the user is logged in
 def login_required_custom(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):


### PR DESCRIPTION
## Description
This PR fixes a security issue where unauthenticated users were able to access the analysis and share pages directly via URL, by passing the login requirement.

## What did I do
- Added login-required decorators to protect dashboard, analysis, share and profile routes.
- Ensured users are redirected to the login page if they attempt to access these pages without authentication.
- Verified that authenticated users can still access these pages normally.

## How to Test
1. Logout of the app (or open in incognito mode).
2. Try accessing the `/analysis` or `/share` route directly — you should be redirected to the login page.
3. Login and verify that you can access both pages as expected.

## Note
If we add new routes in the future that need protection, we just need to add the login-required decorator `@login_required_custom` above the route function.
