### PR TITLE
Backend Development: Implemented deleting account option from Profile page #Issue68

### DIFF
--- a/app.py
+++ b/app.py
@@ -506,6 +506,44 @@ def change_password():
     flash("Password successfully updated. Please log in again.", "success")
     return redirect(url_for('login'))
 
+# Delete account from profile page
+@app.route('/delete_account', methods=['POST'])
+def delete_account():
+    user_id = session.get('user_id')
+    if not user_id:
+        flash("You need to log in to delete your account.", "danger")
+        return redirect(url_for('login'))
+
+    try:
+        # Delete user profile from user table
+        user = User.query.get(user_id)
+        if user:
+            db.session.delete(user)
+
+        # Delete user from useProfile table
+        profile = Profile.query.filter_by(user_id=user_id).first()
+        if profile:
+            db.session.delete(profile)
+
+        # Delete user's budget plan from BudgetPlan table
+        budget_plan = BudgetPlan.query.filter_by(user_id=user_id).first()
+        if budget_plan:
+            db.session.delete(budget_plan)
+
+        # TODO: Add any table 
+        db.session.commit()
+        # Clear session and logout
+        session.clear()
+
+        flash("Your account has been deleted successfully. See you again!", "success")
+        return redirect(url_for('login'))
+
+    except Exception as e:
+        db.session.rollback()
+        flash(f"An error occurred while deleting your account: {str(e)}", "danger")
+        return redirect(url_for('profile'))
+
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -266,6 +266,28 @@
     </div>
 </div>
 
+<!-- Delete Account Modal -->
+<div class="modal fade" id="deleteAccountModal" tabindex="-1" aria-labelledby="deleteAccountLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteAccountLabel">Delete Account</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete your account? This action cannot be undone.
+            </div>
+            <div class="modal-footer">
+                <form method="POST" action="{{ url_for('delete_account') }}">
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
 
 
 {% endblock %}


### PR DESCRIPTION
In this PR, deleting account option has been implemented.

* By clicking the button, Delete modal will pop up and re-confirm for deleting.
* This will delete all the records related to user in tables, such as user, userProfile, and additional analysis tables.
* After deleting, user will be automatically logged out and redirect to login page.