### PR TITLE
Bug: Fixed the 'Shared by another user' message in the Savings Goal Tracker.

### DIFF
--- a/templates/savings_goal_tracker.html
+++ b/templates/savings_goal_tracker.html
@@ -106,7 +106,10 @@
                       {{ progress }}%
                     </div>
                 </div>
-                <p class="card-text"><em>Shared by another user</em></p>
+                <p class="card-text"><strong>Shared by:</strong></p>
+                <div class="d-flex flex-wrap gap-2">
+                    <span class="badge bg-secondary">{{ goal.owner.name }}</span>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Change the "Shared by another user" message in the Shared with me section of the Savings Goal Tracker to the other user's name, so that the current user understands from where he/she got this shared goal.